### PR TITLE
Add team colors file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,18 @@ rcssmonitor
 
 If you invoke `rcssmonitor` with `--help` option, available options are displayed in your console.
 
+## how to change team colors
+the colors data should be in ~/ directory with .rcssmonitor-team-color.csv name
+the format of data should be like this:
+```
+# file: ~/.rcssmonitor-team-color.csv
+
+my-team-name1 r1 g1 b1 r2 g2 b2 r3 g3 b3 ...
+my-team-name2 r1 g1 b1 r2 g2 b2 r3 g3 b3 ...
+...
+...
+```
+
 ## ✉ ️Contributing
 
 For bug reports, feature requests and latest updates, please goto

--- a/src/disp_holder.h
+++ b/src/disp_holder.h
@@ -73,7 +73,6 @@ private:
     LineCont M_line_cont;
 
     rcss::rcg::PlayMode M_playmode; //!< last handled playmode
-    rcss::rcg::TeamT M_teams[2]; //!< last handled team info
 
     //! the list of score changed data index
     std::vector< std::size_t > M_score_changed_index;
@@ -92,6 +91,8 @@ private:
     DispHolder operator=( const DispHolder & );
 
 public:
+
+    rcss::rcg::TeamT M_teams[2]; //!< last handled team info
 
     DispHolder();
     ~DispHolder();

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -2408,6 +2408,73 @@ MainWindow::changePlayMode( int mode,
 void
 MainWindow::receiveMonitorPacket()
 {
+    if (rcss::rcg::Parser::change_team) {
+        std::cout << "Initializing team colors" << std::endl;
+
+        if (Color::team_colors().empty()) {
+            std::cout << "no color file exist or the file is empty. (check file: ~/.rcssmonitor-team-color.csv"
+                      << std::endl;
+
+            Options::instance().setLeftTeamColor(Options::instance().LEFT_TEAM_COLOR);
+            Options::instance().setRightTeamColor(Options::instance().RIGHT_TEAM_COLOR);
+        } else {
+            std::string team_name1 = M_disp_holder.M_teams[0].name_;
+            std::string team_name2 = M_disp_holder.M_teams[1].name_;
+
+            std::vector<Color> colors1;
+            std::vector<Color> colors2;
+
+            if (Color::team_colors().find(team_name1) != Color::team_colors().end())
+                colors1 = Color::team_colors()[team_name1];
+            else
+                colors1 = std::vector<Color>{Color(Options::instance().LEFT_TEAM_COLOR),
+                                             Color(Options::instance().RIGHT_TEAM_COLOR)};
+
+            if (Color::team_colors().find(team_name2) != Color::team_colors().end())
+                colors2 = Color::team_colors()[team_name2];
+            else
+                colors2 = std::vector<Color>{Color(Options::instance().LEFT_TEAM_COLOR),
+                                             Color(Options::instance().RIGHT_TEAM_COLOR)};
+
+
+            const Color field_color(Options::instance().fieldBrush());
+            bool find_colors = false;
+
+            for (const Color &color1: colors1) {
+                if (color1.dist(field_color) < Color::max_diff)
+                    continue;
+
+                for (const Color &color2: colors2) {
+                    if (color2.dist(field_color) < Color::max_diff)
+                        continue;
+
+                    if (color1.dist(color2) < Color::max_diff)
+                        continue;
+
+                    std::cout << "Colors found!" << std::endl
+                              << "left team: " << color1 << "|"
+                              << "right team: " << color2
+                              << std::endl;
+
+                    Options::instance().setLeftTeamColor(color1.to_qcolor());
+                    Options::instance().setRightTeamColor(color2.to_qcolor());
+                    find_colors = true;
+                    break;
+                }
+                if (find_colors)
+                    break;
+            }
+
+            if (!find_colors) {
+                std::cout << "Colors not found! going to default mode" << std::endl;
+
+                Options::instance().setLeftTeamColor(Options::instance().LEFT_TEAM_COLOR);
+                Options::instance().setRightTeamColor(Options::instance().RIGHT_TEAM_COLOR);
+            }
+        }
+        rcss::rcg::Parser::change_team = false;
+    }
+
     if ( M_log_player->isLiveMode() )
     {
         M_log_player->showLive();

--- a/src/options.h
+++ b/src/options.h
@@ -54,6 +54,7 @@ class Options {
 public:
 
     static const QString CONF_FILE;
+    static const QString COLOR_FILE;
 
     enum PlayerSelectType {
         SELECT_FIX,
@@ -652,5 +653,36 @@ public:
     void setMeasureFont( const QFont & font ) { M_measure_font = font; }
 
 };
+
+class Color{
+public:
+    int M_r;
+    int M_g;
+    int M_b;
+
+    Color(int r = 0, int g = 0, int b = 0){
+        M_r = r;
+        M_g = g;
+        M_b = b;
+    }
+
+    Color(const QBrush& qb){
+        M_r = qb.color().red();
+        M_g = qb.color().green();
+        M_b = qb.color().blue();
+    }
+
+    static std::map<std::string, std::vector<Color>> M_team_colors;
+    static double max_diff;
+    static std::map<std::string, std::vector<Color>>& team_colors(){
+        return Color::M_team_colors;
+    }
+
+    QColor to_qcolor() const;
+    static bool initial_teams_color();
+    double dist(const Color& c) const;
+};
+
+std::ostream& operator<<(std::ostream& os, const Color& color);
 
 #endif

--- a/src/rcsslogplayer/parser.cpp
+++ b/src/rcsslogplayer/parser.cpp
@@ -734,6 +734,9 @@ Parser::parseLine( std::istream & is )
     return true;
 }
 
+bool Parser::change_team = false;
+std::string Parser::last_teamname_l = "";
+std::string Parser::last_teamname_r = "";
 
 bool
 Parser::parseLine( const int n_line,
@@ -855,6 +858,17 @@ Parser::parseShowLine( const int n_line,
 
         TeamT team_l( name_l, score_l, pen_score_l, pen_miss_l );
         TeamT team_r( name_r, score_r, pen_score_r, pen_miss_r );
+
+        if (Parser::last_teamname_l.compare(name_l) != 0){
+            Parser::last_teamname_l = name_l;
+            Parser::last_teamname_r = name_r;
+            Parser::change_team = true;
+        }
+        if (Parser::last_teamname_r.compare(name_r) != 0){
+            Parser::last_teamname_l = name_l;
+            Parser::last_teamname_r = name_r;
+            Parser::change_team = true;
+        }
 
         M_handler.handleTeamInfo( time, team_l, team_r );
     }
@@ -1319,7 +1333,6 @@ Parser::parsePlayModeLine( const int n_line,
     return true;
 }
 
-
 bool
 Parser::parseTeamLine( const int n_line,
                        const std::string & line )
@@ -1695,6 +1708,7 @@ Parser::parseServerParamLine( const int n_line,
     double_map.insert( DoubleMap::value_type( "illegal_defense_width", &param.illegal_defense_width_ ) );
     string_map.insert( StringMap::value_type( "fixed_teamname_l", &param.fixed_teamname_l_ ) );
     string_map.insert( StringMap::value_type( "fixed_teamname_r", &param.fixed_teamname_r_ ) );
+
 
     //
     // parse

--- a/src/rcsslogplayer/parser.h
+++ b/src/rcsslogplayer/parser.h
@@ -124,6 +124,9 @@ private:
 
     bool parseLine( std::istream & is );
 public:
+    static bool change_team;
+    static std::string last_teamname_l;
+    static std::string last_teamname_r;
     // can be used by monitor client
     bool parseLine( const int n_line,
                     const std::string & line );


### PR DESCRIPTION
Hello!
I am a member of the Cyrus team and a part of the technical committee of the Iran Open. 
for the league, I've added a config file to rcssmonitor that could determine each team has which color. 
After teams join the rcssserver the monitor checks if the colors of teams are close, if so, the algorithm chooses the secondary color or the other colors of the teams. (the left team has the priority)

a good feature that it has, I added some code that if rcssmonitor be on **auto-connect mode**, and a new match has been begun, the teams' colors change based on their name automatically.

Thanks to Mr. Nader Zare for guiding me in this idea. 